### PR TITLE
_findPlaceDetails now returns an error message in case of bad formatted Google response

### DIFF
--- a/lib/flaneur-geocoder.js
+++ b/lib/flaneur-geocoder.js
@@ -44,8 +44,9 @@ class FlaneurGeocoder {
         return JSON.parse(bodyString)
       })
       .catch((e) => {
+        // This should not happen, as google always send a response.
         console.error('findPlaceDetails:', e)
-        return {}
+        return {error_message: e}
       })
   }
 


### PR DESCRIPTION
Querying Google Places should always return something, but in case of unexpected error (service down or bad formatted response), an error could be thrown.
This error is now sent back to the caller in the property `error_message`.