### PR TITLE
Better Location Retrieval + Minor fixes and Linting

### DIFF
--- a/lib/flaneur-geocoder.js
+++ b/lib/flaneur-geocoder.js
@@ -40,13 +40,11 @@ class FlaneurGeocoder {
 
   _findPlaceDetails(placeID) {
     return rp(`https://maps.googleapis.com/maps/api/place/details/json?placeid=${placeID}&language=en&key=${this.apiKey}`)
-      .then((bodyString) => {
-        return JSON.parse(bodyString)
-      })
+      .then(bodyString => JSON.parse(bodyString))
       .catch((e) => {
         // This should not happen, as google always send a response.
         console.error('findPlaceDetails:', e)
-        return {error_message: e}
+        return { error_message: e }
       })
   }
 
@@ -54,13 +52,12 @@ class FlaneurGeocoder {
     return this._findPlaceDetails(placeID)
       .then((placeDetails) => {
         if (placeDetails.result) {
-          return this._outputFromSingleGooglePlaceResult(placeDetails.result, { placeID: placeID })
+          return this._outputFromSingleGooglePlaceResult(placeDetails.result, { placeID })
+        }
+        if (placeDetails.error_message) {
+          throw new Error(`Couldn't fetch details for place ${placeID}: ${placeDetails.error_message}`)
         } else {
-          if (placeDetails.error_message) {
-            throw new Error(`Couldn't fetch details for place ${placeID}: ${placeDetails.error_message}`)
-          } else {
-            throw new Error(`Couldn't fetch details for place ${placeID}: ${placeDetails.status}`)
-          }
+          throw new Error(`Couldn't fetch details for place ${placeID}: ${placeDetails.status}`)
         }
       })
   }
@@ -78,12 +75,12 @@ class FlaneurGeocoder {
           // Else, use in priority the filtered results but if none, use all the results.
           const localities = withLocalityOnly
             ? filteredResults
-            : (filteredResults.length ? filteredResults : responseObject.results)
+            : (filteredResults.length && filteredResults) || responseObject.results
 
           if (localities.length >= 1) {
             return this._outputFromSingleGooglePlaceResult(localities[0], {
               lat: Number(lat),
-              lng: Number(lng)
+              lng: Number(lng),
             })
           }
           throw new Error(`Couldn't find locality for coordinates ${lat}, ${lng}`)
@@ -177,7 +174,7 @@ class FlaneurGeocoder {
     }
 
     const getFirstPoliticalComponent = function getFirstPoliticalComponent() {
-      return res.enPoliticalComponents[Object.keys(res.enPoliticalComponents)[0]]
+      return politicalComponents[Object.keys(politicalComponents)[0]]
     }
 
     return getLocality() || getHighestAdministrativeArea() || getFirstPoliticalComponent()

--- a/lib/flaneur-geocoder.js
+++ b/lib/flaneur-geocoder.js
@@ -65,22 +65,30 @@ class FlaneurGeocoder {
       })
   }
 
-  _findFromCoordinate(lat, lng) {
+  _findFromCoordinate(lat, lng, withLocalityOnly = false) {
     return rp(`https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&key=${this.apiKey}`)
       .then(bodyString => JSON.parse(bodyString))
       .then((responseObject) => {
         if (responseObject.results) {
-          const localities = responseObject.results.filter(result => result.types && result.types.includes('locality'))
+          // Filter predicate checking if the `types` array includes 'locality' 
+          const includesLocality = (result => result.types && result.types.includes('locality'))
+          // The resulting entries after filter application
+          const filteredResults = responseObject.results.filter(includesLocality)
+          // If withLocalityOnly is true, use only the filtered results.
+          // Else, use in priority the filtered results but if none, use all the results.
+          const localities = withLocalityOnly
+            ? filteredResults
+            : (filteredResults.length ? filteredResults : responseObject.results)
 
-          if (localities.length === 1) {
+          if (localities.length >= 1) {
             return this._outputFromSingleGooglePlaceResult(localities[0], {
               lat: Number(lat),
               lng: Number(lng)
             })
           }
-          throw new Error(`Couldn't find locality for coordainte ${lat}, ${lng}`)
+          throw new Error(`Couldn't find locality for coordinates ${lat}, ${lng}`)
         } else {
-          throw new Error(`Couldn't fetch details for coordainte ${lat}, ${lng}`)
+          throw new Error(`Couldn't fetch details for coordinates ${lat}, ${lng}`)
         }
       })
   }
@@ -149,6 +157,33 @@ class FlaneurGeocoder {
     return newRes
   }
 
+  static _findPlaceName(politicalComponents) {
+    const getLocality = function getLocality() {
+      return politicalComponents.locality || politicalComponents.sublocality || null
+    }
+
+    const getHighestAdministrativeArea = function getHighestAdministrativeArea() {
+      let found = false
+      let level = 5
+      do {
+        if (politicalComponents[`administrative_area_level_${level}`]) {
+          found = true
+        } else {
+          level -= 1
+        }
+      } while (!found && level)
+
+      return level ? politicalComponents[`administrative_area_level_${level}`] : null
+    }
+
+    const getFirstPoliticalComponent = function getFirstPoliticalComponent() {
+      return res.enPoliticalComponents[Object.keys(res.enPoliticalComponents)[0]]
+    }
+
+    return getLocality() || getHighestAdministrativeArea() || getFirstPoliticalComponent()
+  }
+
+
   _outputFromSingleGooglePlaceResult(gpResult, query = null) {
     const res = {}
 
@@ -156,7 +191,7 @@ class FlaneurGeocoder {
     res.enPoliticalComponents = FlaneurGeocoder._extractPoliticalComponents(gpResult)
 
     res.placeID = gpResult.place_id
-    res.name = gpResult.name || res.enPoliticalComponents.locality
+    res.name = gpResult.name || FlaneurGeocoder._findPlaceName(res.enPoliticalComponents)
 
     // We need more information: location and size of the viewport
     if (gpResult.geometry && gpResult.geometry.location) {

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../.eslintrc.json",
+  "rules": {
+    "prefer-arrow-callback": "off",
+    "func-names": "off"
+  },
+  "env": {
+    "mocha": true
+  }
+}

--- a/test/flaneur-geocoder-tests.js
+++ b/test/flaneur-geocoder-tests.js
@@ -1,92 +1,111 @@
-'use strict';
+'use strict'
 
 const chai = require('chai')
 const should = chai.should()
 // const assert = chai.assert
 const chaiAsPromised = require('chai-as-promised')
+
 chai.use(chaiAsPromised)
 
 const FlaneurGeocoder = require('../lib/flaneur-geocoder')
 
-describe('FlaneurGeocoder', function() {
-  describe('#findWhereIs', function() {
-    it('should return a valid response with latitude/longitude', function(done) {
+describe('FlaneurGeocoder', function () {
+  describe('#findWhereIs', function () {
+    it('should return a valid response with latitude/longitude', function (done) {
       const geocoder = new FlaneurGeocoder()
       geocoder.findWhereIs(48.8381, 2.2805)
-      .then((result) => {
-        result.enPoliticalComponents.locality.should.eq('Paris')
-        result.enPoliticalComponents.administrative_area_level_2.should.eq('Paris')
-        result.enPoliticalComponents.administrative_area_level_1.should.eq('Île-de-France')
-        result.enPoliticalComponents.country.should.eq('France')
+        .then((result) => {
+          result.enPoliticalComponents.locality.should.eq('Paris')
+          result.enPoliticalComponents.administrative_area_level_2.should.eq('Paris')
+          result.enPoliticalComponents.administrative_area_level_1.should.eq('Île-de-France')
+          result.enPoliticalComponents.country.should.eq('France')
+          result.name.should.eq('Paris')
 
-        // The inputs arguments should be also returned in the result
-        result.query.lat.should.eq(48.8381)
-        result.query.lng.should.eq(2.2805)
-      })
-      .should.notify(done)
+          // The inputs arguments should be also returned in the result
+          result.query.lat.should.eq(48.8381)
+          result.query.lng.should.eq(2.2805)
+        })
+        .should.notify(done)
     })
 
-    it('should return results in English', function(done) {
+    it('should return a valid response with latitude/longitude with another coordinates', function (done) {
+      const geocoder = new FlaneurGeocoder()
+      geocoder.findWhereIs(38.102, 13.0915833333)
+        .then((result) => {
+          result.enPoliticalComponents.administrative_area_level_3.should.eq('Terrasini')
+          result.enPoliticalComponents.administrative_area_level_2.should.eq('Provincia di Palermo')
+          result.enPoliticalComponents.administrative_area_level_1.should.eq('Sicilia')
+          result.enPoliticalComponents.country.should.eq('Italy')
+          result.name.should.eq('Terrasini')
+
+          // The inputs arguments should be also returned in the result
+          result.query.lat.should.eq(38.102)
+          result.query.lng.should.eq(13.0915833333)
+        })
+        .should.notify(done)
+    })
+
+    it('should return results in English', function (done) {
       const geocoder = new FlaneurGeocoder()
       geocoder.findWhereIs(41.3772, 2.1502)
-      .then((result) => {
-        result.enPoliticalComponents.locality.should.eq('Barcelona')
-      })
-      .should.notify(done)
+        .then((result) => {
+          result.enPoliticalComponents.locality.should.eq('Barcelona')
+        })
+        .should.notify(done)
     })
 
-    it('should convert string coordinate queries to numbers', function(done) {
+    it('should convert string coordinate queries to numbers', function (done) {
       const geocoder = new FlaneurGeocoder()
-      geocoder.findWhereIs("48.8381", "2.2805")
-      .then((result) => {
-        // The inputs arguments should be returned as Numbers
-        result.query.lat.should.eq(48.8381)
-        result.query.lng.should.eq(2.2805)
-      })
-      .should.notify(done)
+      geocoder.findWhereIs('48.8381', '2.2805')
+        .then((result) => {
+          // The inputs arguments should be returned as Numbers
+          result.query.lat.should.eq(48.8381)
+          result.query.lng.should.eq(2.2805)
+        })
+        .should.notify(done)
     })
 
-    it('should return a valid response with a Google Place ID', function(done) {
+    it('should return a valid response with a Google Place ID', function (done) {
       const geocoder = new FlaneurGeocoder()
       geocoder.findWhereIs('ChIJjaFImcB65kcRXCzvbEBQJN0')
-      .then((result) => {
-        result.enPoliticalComponents.locality.should.eq('Paris')
-        result.enPoliticalComponents.administrative_area_level_2.should.eq('Paris')
-        result.enPoliticalComponents.administrative_area_level_1.should.eq('Île-de-France')
-        result.enPoliticalComponents.country.should.eq('France')
+        .then((result) => {
+          result.enPoliticalComponents.locality.should.eq('Paris')
+          result.enPoliticalComponents.administrative_area_level_2.should.eq('Paris')
+          result.enPoliticalComponents.administrative_area_level_1.should.eq('Île-de-France')
+          result.enPoliticalComponents.country.should.eq('France')
 
-        // The inputs arguments should be also returned in the result
-        result.query.placeID.should.eq('ChIJjaFImcB65kcRXCzvbEBQJN0')
-      })
-      .should.notify(done)
+          // The inputs arguments should be also returned in the result
+          result.query.placeID.should.eq('ChIJjaFImcB65kcRXCzvbEBQJN0')
+        })
+        .should.notify(done)
     })
 
-    it ('accepts a custom function to compute aroundRadius', function(done) {
+    it('accepts a custom function to compute aroundRadius', function (done) {
       const geocoder = new FlaneurGeocoder({
-        aroundRadiusFn: function(viewportDiagonal) {
+        aroundRadiusFn(viewportDiagonal) {
           return 4
-        }
+        },
       })
 
       geocoder.findWhereIs('ChIJjaFImcB65kcRXCzvbEBQJN0')
-      .then((result) => {
-        result.searchSettings.aroundRadius.should.eq(4)
-      })
-      .should.notify(done)
+        .then((result) => {
+          result.searchSettings.aroundRadius.should.eq(4)
+        })
+        .should.notify(done)
     })
 
-    it ('accepts a custom function to compute aroundPrecision', function(done) {
+    it('accepts a custom function to compute aroundPrecision', function (done) {
       const geocoder = new FlaneurGeocoder({
-        aroundPrecisionFn: function(viewportDiagonal) {
+        aroundPrecisionFn(viewportDiagonal) {
           return 5
-        }
+        },
       })
 
       geocoder.findWhereIs('ChIJjaFImcB65kcRXCzvbEBQJN0')
-      .then((result) => {
-        result.searchSettings.aroundPrecision.should.eq(5)
-      })
-      .should.notify(done)
+        .then((result) => {
+          result.searchSettings.aroundPrecision.should.eq(5)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/haversine-tests.js
+++ b/test/haversine-tests.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 const chai = require('chai')
 const should = chai.should()
@@ -10,16 +10,16 @@ const paris =   { latitude: 48.856614,  longitude: 2.3522219    }
 const boston =  { latitude: 42.3600825, longitude: -71.0588801  }
 const seattle = { latitude: 47.6062095, longitude: -122.3320708 }
 
-describe('Haversine', function() {
-  describe('#distanceBetween', function() {
-    it('should know the distance between given cities and vice-versa', function() {
+describe('Haversine', function () {
+  describe('#distanceBetween', function () {
+    it('should know the distance between given cities and vice-versa', function () {
       Math.floor(haversine(brest.latitude, brest.longitude, paris.latitude, paris.longitude)).should.eq(505)
       Math.floor(haversine(paris.latitude, paris.longitude, brest.latitude, brest.longitude)).should.eq(505)
       Math.floor(haversine(boston.latitude, boston.longitude, seattle.latitude, seattle.longitude)).should.eq(4000)
       Math.floor(haversine(seattle.latitude, seattle.longitude, boston.latitude, boston.longitude)).should.eq(4000)
     })
 
-    it('should deal with latitude overflow', function() {
+    it('should deal with latitude overflow', function () {
       Math.floor(haversine(-179.9, 0.0, 179.9, 0.0)).should.eq(22)
     })
   })


### PR DESCRIPTION
* Added the `withLocalityOnly` flag to the `_findFromCoordinate` method. When `true`, the method will have the old behaviour, returning `new Error('Couldn't find locality for coordinate ${lat}, ${lng}')` when no result has the `locality` type.
When `false`, the method use in priority a result with the `locality` type. If there is none, the method fall back to the first result, no matter the type.
It is `false` by default, in order to have geolocation details for a maximum of trips.
* Added the `_findPlaceName` method, checking a range of possible names (from best to worst) for a place. The order is the following: `locality > sublocality > administrative_area_level_5 - administrative_area_level_1 > firstPoliticalComponent`, allowing to find a name for any place.
* Corrected typos
* Updated linting