### PR TITLE
Implemented findWhereIsAddress

### DIFF
--- a/lib/flaneur-geocoder.js
+++ b/lib/flaneur-geocoder.js
@@ -26,7 +26,16 @@ class FlaneurGeocoder {
       const googlePlaceID = args[0]
       return this._findFromGooglePlaceID(googlePlaceID)
     }
-    throw new Error('Invalid args')
+    return Promise.reject(new Error('Invalid args'))
+  }
+
+  findWhereIsAddress(address, options = {}) {
+    if (!address) {
+      return Promise.reject(new Error('Invalid args'))
+    }
+
+    const { withLocalityOnly, includeFormattedAddress, language } = options
+    return this._findFromAddress(address, withLocalityOnly, includeFormattedAddress, language)
   }
 
   findPhoto(photoRef, outputName = 'photo') {
@@ -67,18 +76,10 @@ class FlaneurGeocoder {
       .then(bodyString => JSON.parse(bodyString))
       .then((responseObject) => {
         if (responseObject.results) {
-          // Filter predicate checking if the `types` array includes 'locality' 
-          const includesLocality = (result => result.types && result.types.includes('locality'))
-          // The resulting entries after filter application
-          const filteredResults = responseObject.results.filter(includesLocality)
-          // If withLocalityOnly is true, use only the filtered results.
-          // Else, use in priority the filtered results but if none, use all the results.
-          const localities = withLocalityOnly
-            ? filteredResults
-            : (filteredResults.length && filteredResults) || responseObject.results
+          const locality = FlaneurGeocoder._extractResult(responseObject.results, withLocalityOnly)
 
-          if (localities.length >= 1) {
-            return this._outputFromSingleGooglePlaceResult(localities[0], {
+          if (locality) {
+            return this._outputFromSingleGooglePlaceResult(locality, {
               lat: Number(lat),
               lng: Number(lng),
             })
@@ -90,98 +91,24 @@ class FlaneurGeocoder {
       })
   }
 
-  _findFromCoordinateLegacy(lat, lng) {
-    return rp(`https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&key=${this.apiKey}`)
-      .then((bodyString) => {
-        console.log(bodyString)
-        return JSON.parse(bodyString)
-      })
+  _findFromAddress(address, withLocalityOnly = false, includeFormattedAddress = false, language = '') {
+    const endpoint = 'https://maps.googleapis.com/maps/api/geocode/json'
+
+    return rp(`${endpoint}?address=${address}&key=${this.apiKey}&language=${language}`)
+      .then(JSON.parse)
       .then((responseObject) => {
         if (responseObject.results) {
-          const allPoliticalAddressComponents = responseObject.results
-            .map(this._extractPoliticalComponents)
-            .reduce(this._mergeObjects)
-          return allPoliticalAddressComponents
+          const locality = FlaneurGeocoder._extractResult(responseObject.results, withLocalityOnly)
+
+          if (locality) {
+            return this._outputFromSingleGooglePlaceResult(locality, { address }, includeFormattedAddress)
+          }
+          throw new Error(`Couldn't find locality for address ${address}`)
         }
-        console.error(`Empty response for ${lat}, ${lng}`)
-        return {}
-      })
-      .catch((e) => {
-        console.error('_findFromCoordinate:', e)
-        return {}
       })
   }
 
-  static _extractPoliticalComponents(objWithAddressComponents) {
-    const result = {}
-    objWithAddressComponents.address_components.forEach((addressComponent) => {
-      if (addressComponent.types.includes('political')) {
-        const filteredTypes = addressComponent.types.filter(elt => elt !== 'political')
-        if (filteredTypes.length === 1) {
-          const politicalType = filteredTypes[0]
-          result[politicalType] = addressComponent.long_name
-        } else if (filteredTypes.length === 0) {
-          if (verbose) {
-            console.warn('Skipping political type with unique entity', addressComponent)
-          }
-        } else {
-          if (verbose) {
-            console.warn('Splitting type into multiple political components', addressComponent)
-          }
-          filteredTypes.forEach((subElt) => {
-            result[subElt] = addressComponent.long_name
-          })
-        }
-      }
-    })
-    return result
-  }
-
-  static _mergeObjects(accumulator, currentValue) {
-    const newRes = accumulator
-    Object.keys(currentValue).forEach((key) => {
-      if (newRes[key] && newRes[key] !== currentValue[key]) {
-        if (verbose) {
-          console.warn(`Conflict for key ${key}: ${newRes[key]} != ${currentValue[key]}`)
-        }
-        if (newRes[key].length > currentValue[key].length) {
-          newRes[key] = currentValue[key]
-        }
-      } else {
-        newRes[key] = currentValue[key]
-      }
-    })
-    return newRes
-  }
-
-  static _findPlaceName(politicalComponents) {
-    const getLocality = function getLocality() {
-      return politicalComponents.locality || politicalComponents.sublocality || null
-    }
-
-    const getHighestAdministrativeArea = function getHighestAdministrativeArea() {
-      let found = false
-      let level = 5
-      do {
-        if (politicalComponents[`administrative_area_level_${level}`]) {
-          found = true
-        } else {
-          level -= 1
-        }
-      } while (!found && level)
-
-      return level ? politicalComponents[`administrative_area_level_${level}`] : null
-    }
-
-    const getFirstPoliticalComponent = function getFirstPoliticalComponent() {
-      return politicalComponents[Object.keys(politicalComponents)[0]]
-    }
-
-    return getLocality() || getHighestAdministrativeArea() || getFirstPoliticalComponent()
-  }
-
-
-  _outputFromSingleGooglePlaceResult(gpResult, query = null) {
+  _outputFromSingleGooglePlaceResult(gpResult, query = null, includeFormattedAddress = false) {
     const res = {}
 
     res.types = gpResult.types
@@ -189,6 +116,10 @@ class FlaneurGeocoder {
 
     res.placeID = gpResult.place_id
     res.name = gpResult.name || FlaneurGeocoder._findPlaceName(res.enPoliticalComponents)
+
+    if (includeFormattedAddress && gpResult.formatted_address) {
+      res.formatted_address = gpResult.formatted_address
+    }
 
     // We need more information: location and size of the viewport
     if (gpResult.geometry && gpResult.geometry.location) {
@@ -230,6 +161,68 @@ class FlaneurGeocoder {
     return res
   }
 
+  static _extractResult(results, withLocalityOnly) {
+    // Filter predicate checking if the `types` array includes 'locality' 
+    const includesLocality = (result => result.types && result.types.includes('locality'))
+    // The resulting entry after filter application
+    const resultWithLocality = results.find(includesLocality)
+
+    // If withLocalityOnly is true, try to find a result containing a locality
+    // Else, use in priority the filtered results but if none, use all the results.
+    return withLocalityOnly ? resultWithLocality : (resultWithLocality || results[0])
+  }
+
+  static _extractPoliticalComponents(objWithAddressComponents) {
+    const result = {}
+    objWithAddressComponents.address_components.forEach((addressComponent) => {
+      if (addressComponent.types.includes('political')) {
+        const filteredTypes = addressComponent.types.filter(elt => elt !== 'political')
+        if (filteredTypes.length === 1) {
+          const politicalType = filteredTypes[0]
+          result[politicalType] = addressComponent.long_name
+        } else if (filteredTypes.length === 0) {
+          if (verbose) {
+            console.warn('Skipping political type with unique entity', addressComponent)
+          }
+        } else {
+          if (verbose) {
+            console.warn('Splitting type into multiple political components', addressComponent)
+          }
+          filteredTypes.forEach((subElt) => {
+            result[subElt] = addressComponent.long_name
+          })
+        }
+      }
+    })
+    return result
+  }
+
+  static _findPlaceName(politicalComponents) {
+    const getLocality = function getLocality() {
+      return politicalComponents.locality || politicalComponents.sublocality || null
+    }
+
+    const getHighestAdministrativeArea = function getHighestAdministrativeArea() {
+      let found = false
+      let level = 5
+      do {
+        if (politicalComponents[`administrative_area_level_${level}`]) {
+          found = true
+        } else {
+          level -= 1
+        }
+      } while (!found && level)
+
+      return level ? politicalComponents[`administrative_area_level_${level}`] : null
+    }
+
+    const getFirstPoliticalComponent = function getFirstPoliticalComponent() {
+      return politicalComponents[Object.keys(politicalComponents)[0]]
+    }
+
+    return getLocality() || getHighestAdministrativeArea() || getFirstPoliticalComponent()
+  }
+
   static _mapsCenteredOnLocation(latitude, longitude) {
     return `https://www.google.com/maps/@?api=1&map_action=map&center=${latitude},${longitude}&zoom=5`
   }
@@ -242,6 +235,46 @@ class FlaneurGeocoder {
   // This is the default for `aroundPrecisionFn`
   static _dividesByFour(viewportDiagonal) {
     return viewportDiagonal / 4.0
+  }
+
+  /* ***************************************** LEGACY ***************************************** */
+  _findFromCoordinateLegacy(lat, lng) {
+    return rp(`https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&key=${this.apiKey}`)
+      .then((bodyString) => {
+        console.log(bodyString)
+        return JSON.parse(bodyString)
+      })
+      .then((responseObject) => {
+        if (responseObject.results) {
+          const allPoliticalAddressComponents = responseObject.results
+            .map(this._extractPoliticalComponents)
+            .reduce(this._mergeObjects)
+          return allPoliticalAddressComponents
+        }
+        console.error(`Empty response for ${lat}, ${lng}`)
+        return {}
+      })
+      .catch((e) => {
+        console.error('_findFromCoordinate:', e)
+        return {}
+      })
+  }
+
+  static _mergeObjects(accumulator, currentValue) {
+    const newRes = accumulator
+    Object.keys(currentValue).forEach((key) => {
+      if (newRes[key] && newRes[key] !== currentValue[key]) {
+        if (verbose) {
+          console.warn(`Conflict for key ${key}: ${newRes[key]} != ${currentValue[key]}`)
+        }
+        if (newRes[key].length > currentValue[key].length) {
+          newRes[key] = currentValue[key]
+        }
+      } else {
+        newRes[key] = currentValue[key]
+      }
+    })
+    return newRes
   }
 }
 

--- a/lib/flaneur-geocoder.js
+++ b/lib/flaneur-geocoder.js
@@ -34,8 +34,8 @@ class FlaneurGeocoder {
       return Promise.reject(new Error('Invalid args'))
     }
 
-    const { withLocalityOnly, includeFormattedAddress, language } = options
-    return this._findFromAddress(address, withLocalityOnly, includeFormattedAddress, language)
+    const { withLocalityOnly, withFormattedAddress, language } = options
+    return this._findFromAddress(address, withLocalityOnly, withFormattedAddress, language)
   }
 
   findPhoto(photoRef, outputName = 'photo') {
@@ -91,7 +91,7 @@ class FlaneurGeocoder {
       })
   }
 
-  _findFromAddress(address, withLocalityOnly = false, includeFormattedAddress = false, language = '') {
+  _findFromAddress(address, withLocalityOnly = false, withFormattedAddress = false, language = '') {
     const endpoint = 'https://maps.googleapis.com/maps/api/geocode/json'
 
     return rp(`${endpoint}?address=${address}&key=${this.apiKey}&language=${language}`)
@@ -100,15 +100,15 @@ class FlaneurGeocoder {
         if (responseObject.results) {
           const locality = FlaneurGeocoder._extractResult(responseObject.results, withLocalityOnly)
 
-          if (locality) {
-            return this._outputFromSingleGooglePlaceResult(locality, { address }, includeFormattedAddress)
-          }
-          throw new Error(`Couldn't find locality for address ${address}`)
+          return locality
+            ? this._outputFromSingleGooglePlaceResult(locality, { address }, withFormattedAddress)
+            : Promise.reject(new Error(`Couldn't find locality for address ${address}`))
         }
+        return Promise.reject(new Error(`Couldn't fetch details for address ${address}`))
       })
   }
 
-  _outputFromSingleGooglePlaceResult(gpResult, query = null, includeFormattedAddress = false) {
+  _outputFromSingleGooglePlaceResult(gpResult, query = null, withFormattedAddress = false) {
     const res = {}
 
     res.types = gpResult.types
@@ -117,7 +117,7 @@ class FlaneurGeocoder {
     res.placeID = gpResult.place_id
     res.name = gpResult.name || FlaneurGeocoder._findPlaceName(res.enPoliticalComponents)
 
-    if (includeFormattedAddress && gpResult.formatted_address) {
+    if (withFormattedAddress && gpResult.formatted_address) {
       res.formatted_address = gpResult.formatted_address
     }
 

--- a/test/flaneur-geocoder-tests.js
+++ b/test/flaneur-geocoder-tests.js
@@ -108,4 +108,91 @@ describe('FlaneurGeocoder', function () {
         .should.notify(done)
     })
   })
+
+  describe('#findWhereIsAddress', function () {
+    it('should throw an error with no argument', function () {
+      const geocoder = new FlaneurGeocoder()
+      return geocoder.findWhereIsAddress().should.be.rejectedWith('Invalid args')
+    })
+
+    it('should find the address', function () {
+      const geocoder = new FlaneurGeocoder()
+      const address = '101-199 Elm St, Idaho Falls, ID 83402, USA'
+      const expectedResult = {
+        types: ['street_address'],
+        enPoliticalComponents: {
+          locality: 'Idaho Falls',
+          administrative_area_level_2: 'Bonneville County',
+          administrative_area_level_1: 'Idaho',
+          country: 'United States',
+        },
+        placeID: 'EiYxOTkgRWxtIFN0LCBJZGFobyBGYWxscywgSUQgODM0MDIsIFVTQQ',
+        name: 'Idaho Falls',
+        location: { lat: 43.489884, lng: -112.0374838 },
+        viewport: {
+          northeast: { lat: 43.4912329802915, lng: -112.0361348197085 },
+          southwest: { lat: 43.4885350197085, lng: -112.0388327802915 },
+        },
+        searchSettings: {
+          coordinate: { lat: 43.489884, lng: -112.0374838 },
+          tag: null,
+          aroundPrecision: 92.65883491616987,
+          aroundRadius: 741.2706793293589,
+        },
+        query: { address: '101-199 Elm St, Idaho Falls, ID 83402, USA' },
+      }
+
+      return geocoder.findWhereIsAddress(address)
+        .then(results => results.should.deep.equal(expectedResult))
+    })
+
+    it('should reject if there isn\'t a result with the locality type with the withLocalityOnly option', function () {
+      const geocoder = new FlaneurGeocoder()
+      const address = '101-199 Elm St, Idaho Falls, ID 83402, USA'
+
+      return geocoder.findWhereIsAddress(address, { withLocalityOnly: true }).should.be.rejectedWith('Couldn\'t find locality')
+    })
+
+    it('Should return the formatted address with the includeFormattedAddress option', function () {
+      const geocoder = new FlaneurGeocoder()
+      const address = '101-199 Elm St, Idaho Falls, ID 83402, USA'
+
+      return geocoder.findWhereIsAddress(address, { includeFormattedAddress: true })
+        .then(results => results.should.have.property('formatted_address', '199 Elm St, Idaho Falls, ID 83402, USA'))
+    })
+
+    it('Should translate the address with the language option', function () {
+      const geocoder = new FlaneurGeocoder()
+      const address = '101-199 Elm St, Idaho Falls, ID 83402, USA'
+
+      return geocoder.findWhereIsAddress(address, { includeFormattedAddress: true, language: 'fr' })
+        .then(results => results.should.have.property('formatted_address', '199 Elm St, Idaho Falls, ID 83402, États-Unis'))
+    })
+  })
+
+  describe('#_findFromCoordinate', function () {
+    it('should reject if there isn\'t a result with the locality type with the withLocalityOnly option', function () {
+      const geocoder = new FlaneurGeocoder()
+      return geocoder._findFromCoordinate(48.3951666667, -4.428, true).should.be.rejectedWith(Error)
+    })
+
+    it('should succeed even if there isn\'t a result with the locality type without the withLocalityOnly option ', function () {
+      const geocoder = new FlaneurGeocoder()
+      return geocoder._findFromCoordinate(48.3951666667, -4.428, false)
+        .then((result) => {
+          result.should.deep.include({
+            enPoliticalComponents: {
+              locality: 'Guipavas',
+              administrative_area_level_2: 'Finistère',
+              administrative_area_level_1: 'Bretagne',
+              country: 'France',
+            },
+            placeID: 'Eig2IFJ1ZSBkZSBQYWxhcmVuLCAyOTQ5MCBHdWlwYXZhcywgRnJhbmNl',
+            name: 'Guipavas',
+            query: { lat: 48.3951666667, lng: -4.428 },
+          })
+          return true
+        }).should.eventually.be.true
+    })
+  })
 })

--- a/test/flaneur-geocoder-tests.js
+++ b/test/flaneur-geocoder-tests.js
@@ -153,11 +153,11 @@ describe('FlaneurGeocoder', function () {
       return geocoder.findWhereIsAddress(address, { withLocalityOnly: true }).should.be.rejectedWith('Couldn\'t find locality')
     })
 
-    it('Should return the formatted address with the includeFormattedAddress option', function () {
+    it('Should return the formatted address with the withFormattedAddress option', function () {
       const geocoder = new FlaneurGeocoder()
       const address = '101-199 Elm St, Idaho Falls, ID 83402, USA'
 
-      return geocoder.findWhereIsAddress(address, { includeFormattedAddress: true })
+      return geocoder.findWhereIsAddress(address, { withFormattedAddress: true })
         .then(results => results.should.have.property('formatted_address', '199 Elm St, Idaho Falls, ID 83402, USA'))
     })
 
@@ -165,7 +165,7 @@ describe('FlaneurGeocoder', function () {
       const geocoder = new FlaneurGeocoder()
       const address = '101-199 Elm St, Idaho Falls, ID 83402, USA'
 
-      return geocoder.findWhereIsAddress(address, { includeFormattedAddress: true, language: 'fr' })
+      return geocoder.findWhereIsAddress(address, { withFormattedAddress: true, language: 'fr' })
         .then(results => results.should.have.property('formatted_address', '199 Elm St, Idaho Falls, ID 83402, États-Unis'))
     })
   })


### PR DESCRIPTION
Linked to https://github.com/FlaneurApp/flaneur-admin-cli/issues/33

* Added `findWhereIsAddress`, to geocode from an address. The following options are available:
  * `withLocalityOnly`: retrieve address only if the `locality` type is present
  * `withFormattedAddress`: Retrieve the formatted address by Google. Useful for address correction
  * `language`: Specify in which language the address should be
* Reorganised code
* Added tests

